### PR TITLE
Funcref

### DIFF
--- a/ScanController_v1.7.ipf
+++ b/ScanController_v1.7.ipf
@@ -610,8 +610,6 @@ function RecordValues(i, j, [scandirection,readvstime])
 	variable innerindex, outerindex
 	nvar sc_abortsweep, sc_pause,sc_scanstarttime
 	
-	DoUpdate /W=SweepControl /E=1
-	
 	if (sc_is2d)
 		// 2d
 		innerindex = j

--- a/ScanController_v1.7.ipf
+++ b/ScanController_v1.7.ipf
@@ -329,7 +329,8 @@ function InitializeWaves(start, fin, numpts, [starty, finy, numptsy, x_label, y_
 	variable /g sc_is2d, sc_scanstarttime = datetime
 	variable /g sc_startx, sc_finx, sc_numptsx, sc_starty, sc_finy, sc_numptsy
 	variable/g sc_abortsweep=0, sc_pause=0
-	string graphlist, graphname, plottitle, graphtitle="", graphnumlist="", graphnum, activegraphs="", cmd1=""
+	string graphlist, graphname, plottitle, graphtitle="", graphnumlist="", graphnum, activegraphs="", cmd1="",window_string=""
+	string cmd2=""
 	variable index, graphopen, graphopen2d
 	
 	//do some sanity checks on wave names: they should not start or end with numbers.
@@ -598,7 +599,10 @@ function InitializeWaves(start, fin, numpts, [starty, finy, numptsy, x_label, y_
 	cmd1 = "TileWindows/O=1/A=(3,4) "
 	// Tile graphs
 	for(i=0;i<itemsinlist(activegraphs);i=i+1)
-		cmd1+= stringfromlist(i,activegraphs)+","
+		window_string = stringfromlist(i,activegraphs)
+		cmd1+= window_string +","
+		cmd2 = "DoWindow/F " + window_string
+		execute(cmd2)
 	endfor
 	cmd1 += "SweepControl"
 	execute(cmd1)


### PR DESCRIPTION
This branch was an attempt to speed up RecordValues by removing calls to execute() and replacing them with function and wave references. The speed increase there was marginal ~6.5->6.4ms/call on my machine. 

To make this work, I had to remove the ability to make multiple function calls in a Response/Request loop. Also, we have lost the ability to put arguments in the Response/Request functions. All scripts need to look like `getParam()` and `setParam()`. 

The Calculated wave scripts work the same way as always.

I think this is a much more Igor-approved way of doing things, I also think the loss of functionality is not significant. The code is much easier to read if Requests and Responses are wrapped in the way described above.