### PR TITLE
change path and extention for sc config files

### DIFF
--- a/ScanController_v1.7.ipf
+++ b/ScanController_v1.7.ipf
@@ -1350,10 +1350,6 @@ function sc_loadconfig(filelist)
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	sc_ColorMap = removeending(loadcontainer,"\r")
 	
-	// load filenum
-//	freadline/t=(num2char(13)) refnum, loadcontainer
-//	filenum = str2num(removeending(loadcontainer,"\r"))
-	
 	close refnum
 end
 

--- a/ScanController_v1.7.ipf
+++ b/ScanController_v1.7.ipf
@@ -51,12 +51,14 @@ function InitScanController()
 	string filelist = ""
 	
 	GetFileFolderInfo/z/q/p=data
+	
 	if(v_flag==0)
 		filelist = greplist(indexedfile(data,-1,".txt"),"config")
 	endif
+	
 	if(itemsinlist(filelist)>0)
 		// read content into waves
-		loadconfig(filelist)
+		sc_loadconfig(filelist)
 	else
 		// These arrays should have the same size. Their indeces correspond to each other.
 		make/t/o sc_RawWaveNames = {"g1x", "g1y"} // Wave names to be created and saved
@@ -93,10 +95,10 @@ function InitScanController()
 	// variable to keep track of abort operations
 	variable /g sc_AbortSave = 0
 	
-	rebuildwindow()
+	sc_rebuildwindow()
 end
 
-function rebuildwindow()
+function sc_rebuildwindow()
 	dowindow /k ScanController
 	execute("ScanController()")
 end
@@ -259,7 +261,7 @@ end
 function sc_updatewindow(action) : ButtonControl
 	string action
 	// Write (or overwrite) a config file
-	createconfig()
+	sc_createconfig()
 end
 
 function sc_addrow(action) : ButtonControl
@@ -289,7 +291,7 @@ function sc_addrow(action) : ButtonControl
 			AppendString(sc_CalcScripts, "")
 		break
 	endswitch
-	rebuildwindow()
+	sc_rebuildwindow()
 end
 
 function sc_removerow(action) : Buttoncontrol
@@ -327,7 +329,7 @@ function sc_removerow(action) : Buttoncontrol
 			endif
 			break
 	endswitch
-	rebuildwindow()
+	sc_rebuildwindow()
 end
 
 function AppendValue(thewave, thevalue)
@@ -1225,7 +1227,7 @@ function sc_readvstime(i, j, delay, timeout)
 	endif
 end
 
-function createconfig()
+function sc_createconfig()
 	wave/t sc_RawWaveNames
 	wave sc_RawRecord
 	wave sc_RawPlot
@@ -1241,19 +1243,25 @@ function createconfig()
 	svar sc_ColorMap
 	nvar filenum
 	variable refnum
-	string configfile
+	string configfile, datapath, configpath
 	
 	// Check if data path is definded
 	GetFileFolderInfo/Z/Q/P=data
+	
 	if(v_flag != 0 || v_isfolder != 1)
-		print "Data path no defined. No config file created!"
+		print "Data path no defined. No config file created!\n"
 		return 0
+	else
+		pathinfo data; datapath=S_path
+		configpath = datapath+"config:"
+		newpath /C/O/Q config configpath // easier just to add/create a path than to check
 	endif
 	
-	configfile = "config" + num2istr(unixtime()) + ".txt"
+	configfile = "sc" + num2istr(unixtime()) + ".config"
 	
 	// Try to open config file or create it otherwise
-	open /z/p=data refnum as configfile
+	open /z/p=config refnum as configfile
+	
 	wfprintf refnum, "%s,", sc_RawWaveNames
 	fprintf refnum, "\r"
 	wfprintf refnum, "%g,", sc_RawRecord
@@ -1277,10 +1285,11 @@ function createconfig()
 	fprintf refnum, "%s\r", sc_LogStr
 	fprintf refnum, "%s\r", sc_ColorMap
 	fprintf refnum, "%g\r", filenum
+	
 	close refnum
 end
 
-function loadconfig(filelist)
+function sc_loadconfig(filelist)
 	string filelist
 	variable refnum
 	string loadcontainer
@@ -1291,19 +1300,18 @@ function loadconfig(filelist)
 	nvar filenum
 	variable i, confignum=0
 	string file_string, configunix
+	
 	make/o/d/n=(itemsinlist(filelist)) configmax=0
 	
 	for(i=0;i<itemsinlist(filelist);i=i+1)
 		file_string = stringfromlist(i,filelist)
-		splitstring/e=("config([[:digit:]]+).txt") file_string, configunix
+		splitstring/e=("sc([[:digit:]]+).config") file_string, configunix
 		confignum = str2num(configunix)
 		configmax[i] = confignum
 	endfor
 	confignum = wavemax(configmax)
-	// print configmax
-	// print confignum
 	
-	open /z/r/p=data refnum as "config"+num2istr(confignum)+".txt"
+	open /z/r/p=config refnum as "sc"+num2istr(confignum)+".config"
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	list2textwave(removeending(loadcontainer,"\r"),"sc_RawWaveNames")
 	freadline/t=(num2char(13)) refnum, loadcontainer

--- a/ScanController_v1.7.ipf
+++ b/ScanController_v1.7.ipf
@@ -50,10 +50,10 @@ end
 function InitScanController()
 	string filelist = ""
 	
-	GetFileFolderInfo/z/q/p=data
+	GetFileFolderInfo/z/q/p=config
 	
 	if(v_flag==0)
-		filelist = greplist(indexedfile(data,-1,".txt"),"config")
+		filelist = greplist(indexedfile(config,-1,".config"),"sc")
 	endif
 	
 	if(itemsinlist(filelist)>0)
@@ -86,10 +86,10 @@ function InitScanController()
 			
 		nvar filenum
 		if (numtype(filenum) == 2)
-			print "Initializing FileNum to 0 since it didn't exist before."
+			print "Initializing FileNum to 0 since it didn't exist before.\n"
 			variable /g filenum=0
 		else
-			printf "Current FileNum is %d", filenum
+			printf "Current FileNum is %d\n", filenum
 		endif
 	endif
 	// variable to keep track of abort operations
@@ -150,12 +150,12 @@ Window ScanController() : Panel
 	variable sc_InnerBoxW = 660, sc_InnerBoxH = 32, sc_InnerBoxSpacing = 2
 
 	if (numpnts(sc_RawWaveNames) != numpnts(sc_RawRecord) ||  numpnts(sc_RawWaveNames) != numpnts(sc_RequestScripts) ||  numpnts(sc_RawWaveNames) != numpnts(sc_GetResponseScripts)) 
-		print "sc_RawWaveNames and sc_RawRecord and sc_RequestScripts and sc_GetResponseScripts waves should have the number of elements. Go to the beginning of InitScanController() to fix this."
+		print "sc_RawWaveNames, sc_RawRecord, sc_RequestScripts, and sc_GetResponseScripts waves should have the number of elements.\nGo to the beginning of InitScanController() to fix this.\n"
 		abort
 	endif
 
 	if (numpnts(sc_CalcWaveNames) != numpnts(sc_CalcRecord) ||  numpnts(sc_CalcWaveNames) != numpnts(sc_CalcScripts)) 
-		print "sc_RawWaveNames and sc_DeviceRecord waves should have the number of elements. Go to the beginning of InitScanController() to fix this."
+		print "sc_CalcWaveNames, sc_CalcRecord, and sc_CalcScripts waves should have the number of elements.\n  Go to the beginning of InitScanController() to fix this.\n"
 		abort
 	endif
 
@@ -346,7 +346,7 @@ function AppendString(thewave, thestring)
 	thewave[numpnts(thewave)-1] = thestring
 end
 
-// When a check-box is clicked, which means its value has probably changed, all I do is update the contents of the sc_DeviceRecord wave corresonding to that check-box.
+// Update after checkbox clicked
 function sc_CheckboxClicked(ControlName, Value)
 	string ControlName
 	variable value
@@ -1312,6 +1312,9 @@ function sc_loadconfig(filelist)
 	confignum = wavemax(configmax)
 	
 	open /z/r/p=config refnum as "sc"+num2istr(confignum)+".config"
+	printf "Loading configuration from: %s\n", "sc"+num2istr(confignum)+".config"
+	
+	// load raw wave configuration
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	list2textwave(removeending(loadcontainer,"\r"),"sc_RawWaveNames")
 	freadline/t=(num2char(13)) refnum, loadcontainer
@@ -1322,24 +1325,35 @@ function sc_loadconfig(filelist)
 	list2textwave(removeending(loadcontainer,"\r"),"sc_RequestScripts")
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	list2textwave(removeending(loadcontainer,"\r"),"sc_GetResponseScripts")
+	
+	// load calc wave configuration
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	list2textwave(removeending(loadcontainer,"\r"),"sc_CalcWaveNames")
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	list2textwave(removeending(loadcontainer,"\r"),"sc_CalcScripts")
 	freadline/t=(num2char(13)) refnum, loadcontainer
-	list2numwave(removeending(loadcontainer,"\r")," sc_CalcRecord")
+	list2numwave(removeending(loadcontainer,"\r"),"sc_CalcRecord")
 	freadline/t=(num2char(13)) refnum, loadcontainer
-	list2numwave(removeending(loadcontainer,"\r")," sc_CalcPlot")
+	list2numwave(removeending(loadcontainer,"\r"),"sc_CalcPlot")
+	
+	// load print checkbox settings
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	sc_PrintRaw = str2num(removeending(loadcontainer,"\r"))
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	sc_PrintCalc = str2num(removeending(loadcontainer,"\r"))
+	
+	// load log string
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	sc_LogStr = removeending(loadcontainer,"\r")
+	
+	// load colormap
 	freadline/t=(num2char(13)) refnum, loadcontainer
 	sc_ColorMap = removeending(loadcontainer,"\r")
-	freadline/t=(num2char(13)) refnum, loadcontainer
-	filenum = str2num(removeending(loadcontainer,"\r"))
+	
+	// load filenum
+//	freadline/t=(num2char(13)) refnum, loadcontainer
+//	filenum = str2num(removeending(loadcontainer,"\r"))
+	
 	close refnum
 end
 


### PR DESCRIPTION
Changed path and extension for ScanController configuration files. 

I didn't want to have to add a bunch of exceptions to the cronjob that is fetching data on the server, so I gave the configuration files a *.config extension instead of *.txt. It is makes the rsync backup much cleaner. I also put them in a new path ~/data/config in Igor, so I didn't have to look at them all mixed up with my *ibw files in the main data folder.