### PR TITLE
updated how the waves are initialized and extra demod buttons were made

### DIFF
--- a/Analysis/basics_new.ipf
+++ b/Analysis/basics_new.ipf
@@ -931,8 +931,8 @@ macro testLI()
 closeallGraphs()
 sc_openInstrConnections(0)
 setFdacAWGSquareWave(fd, 100, -100, 0.001, 0.001, 0)
-setupAWG(fd, AWs="0", DACs="0", numCycles=1, verbose=1);
-ScanFastDAC(fd, 0, 1, "3", sweeprate=1,  use_awg=1,nosave=1, repeats = 1)
+setupAWG(fd, AWs="0", DACs="0", numCycles=1, verbose=1)
+ScanFastDAC(fd, 0, 1, "3", sweeprate=1,  use_awg=1,nosave = 0, repeats = 2)
 
 //lock_in_main_2d(wave0_2d,1)
 //demodulate(filenum,1,"wa,[append2hdf])

--- a/Required/ScanController.ipf
+++ b/Required/ScanController.ipf
@@ -943,24 +943,22 @@ function sci_initializeWaves(S)  // TODO: rename
 	
     struct ScanVars &S
     variable fastdac
-
-    variable numpts  // Numpts to initialize wave with, note: for Filtered data, this number is reduced
-    string wavenames, wn
+    variable numpts  //Numpts to initialize wave with, note: for Filtered data, this number is reduced
+    string wavenames, wn, rawwavenames, rwn
     variable raw, j
-    
     wave fadcattr
     
+    rawwavenames = sci_get1DWaveNames(1, S.using_fastdac)
+    
     for (raw = 0; raw<2; raw++)                                      // (raw = 0 means calc waves)
-    	//raw = 0 -> creates waves for raw data at 
-    	//raw = 1 -> checks if the resample box has been ticked and returns correct numpts on x-axis
-
-        wavenames = sci_get1DWaveNames(raw, S.using_fastdac)
-        sci_sanityCheckWavenames(wavenames)
+		wavenames = sci_get1DWaveNames(raw, S.using_fastdac)
+		sci_sanityCheckWavenames(wavenames)
     	
-    	for (j=0; j<itemsinlist(wavenames);j++)
-        
+		for (j=0; j<itemsinlist(wavenames);j++)
+		
         	wn = stringFromList(j, wavenames)
-        	string wavenum = wn[4,strlen(wn)]
+        	rwn = stringFromList(j, rawwavenames)
+        	string wavenum = rwn[3,strlen(rwn)]
         	
         	if (S.using_fastdac && fadcattr[str2num(wavenum)][8] == 48) // Checkbox checked
 	        	numpts = (raw) ? S.numptsx : scfd_postFilterNumpts(S.numptsx, S.measureFreq)   
@@ -968,13 +966,12 @@ function sci_initializeWaves(S)  // TODO: rename
 	     		numpts = S.numptsx
 	     	endif
 	 
-          
           sci_init1DWave(wn, numpts, S.startx, S.finx)
             
           if (S.is2d == 1)
           	sci_init2DWave(wn+"_2d", numpts, S.startx, S.finx, S.numptsy, S.starty, S.finy)
           endif
-            
+           
        endfor
         
 	endfor

--- a/Required/ScanController.ipf
+++ b/Required/ScanController.ipf
@@ -884,56 +884,6 @@ function initializeScan(S, [init_graphs])
 end
 
 
-//function sci_initializeWaves(S)  // TODO: rename
-//   // Initializes the waves necessary for recording scan
-//	// Need 1D and 2D waves for the raw data coming from the fastdac (2D for storing, not necessarily displaying)
-//	// 	Need 2D waves for either the raw data, or filtered data if a filter is set
-//	// (If a filter is set, the raw waves should only ever be plotted 1D)
-//	//	(This will be after calc (i.e. don't need before and after calc wave))
-//	
-//
-//	
-//	struct ScanVars &S
-//	variable fastdac
-//	
-//	variable numpts  // Numpts to initialize wave with, note: for Filtered data, this number is reduced
-//	string wavenames, wn
-//	variable raw, j
-//	
-//	wave fadcattr
-//	string rwn, cwn
-//	string RawWaveNames1D = sci_get1DWaveNames(1, 1)
-//	string CalcWaveNames1D = sci_get1DWaveNames(0, 1)
-// 
-//   sci_sanityCheckWavenames(CalcWaveNames1D)
-//    
-//   for (raw = 0; raw<2; raw++)                                      // (raw = 0 means calc waves)
-//    	//raw = 0 -> creates waves for raw data at 
-//    	//raw = 1 -> checks if the resample box has been ticked and returns correct numpts on x-axis
-//    	
-//    	for (j=0; j<itemsinlist(CalcWaveNames1D);j++)
-//        
-//        	rwn = stringFromList(j, RawWavenames1D)
-//        	cwn = stringFromList(j, CalcWaveNames1D)
-//        	
-//        	string wavenum = rwn[3,strlen(rwn)]
-//        	
-//        	if (S.using_fastdac && fadcattr[str2num(wavenum)][8] == 48) // Checkbox checked
-//	        	numpts = (raw) ? S.numptsx : scfd_postFilterNumpts(S.numptsx, S.measureFreq)   
-//	     	else
-//	     		numpts = S.numptsx
-//	     	endif
-//          
-//          sci_init1DWave(cwn, numpts, S.startx, S.finx)
-//            
-//          if (S.is2d == 1)
-//          	sci_init2DWave(cwn+"_2d", numpts, S.startx, S.finx, S.numptsy, S.starty, S.finy)
-//          endif
-//            
-//       endfor
-//        
-//	endfor
-
 function sci_initializeWaves(S)  // TODO: rename
    // Initializes the waves necessary for recording scan
 	// Need 1D and 2D waves for the raw data coming from the fastdac (2D for storing, not necessarily displaying)


### PR DESCRIPTION
the waves had to pass a condition that looked at the value of a number indicated in the wave name. The default wave name for example would be wave0. It used the "0" value to pass the condition on line 963. It previously did not account for name changes (we often change the names, for example to "cscurrent". To work around this issue, I am using the raw wave names (ADC0,ADC1.,....) to pass the condition.

demod buttons were added to seperate out the demodulation in x vs demodulation in y